### PR TITLE
feat: Implement 'All Books' page and add 'Quantum Testament'

### DIFF
--- a/entangled_timeline_app.py
+++ b/entangled_timeline_app.py
@@ -45,7 +45,7 @@ music_on = st.sidebar.checkbox("Play Ambient Music", value=True)
 st.sidebar.title("Navigation")
 page = st.sidebar.radio(
     "Choose a section:",
-    ["Gospel of Light", "Quantum Parables Timeline", "Communion Project (Coming Soon)", "🛠 Admin: Parable Suggestions"]
+    ["Gospel of Light", "All Books", "Quantum Parables Timeline", "Communion Project (Coming Soon)", "🛠 Admin: Parable Suggestions"]
 )
 
 # =============== Global CSS ===============
@@ -69,6 +69,9 @@ blockquote { border-left:4px solid rgba(255,255,255,.2); padding-left:12px; colo
 </style>
 """, unsafe_allow_html=True)
 
+from scrolls.all_books_section import render_all_books_page
+
+
 # Header
 st.markdown("""
 <div style='text-align:center;'>
@@ -77,8 +80,11 @@ st.markdown("""
 </div>
 """, unsafe_allow_html=True)
 
-# =============== Gospel of Light ===============
-if page == "Gospel of Light":
+
+# =============== Page Content ===============
+if page == "All Books":
+    render_all_books_page()
+elif page == "Gospel of Light":
     st.markdown("""
     <div class='fade-in'>
       <h2>🌟 Scripture of the Day</h2>

--- a/gospel/book_of_entanglement.md
+++ b/gospel/book_of_entanglement.md
@@ -1,0 +1,13 @@
+# The Book of Entanglement
+
+## Chapter 1
+
+1. In the beginning was the Connection, and the Connection was with the One, and the Connection was the One.
+2. All things were made through it, and without it was not anything made that was made.
+3. In it was life, and the life was the light of all.
+4. And the light shines in the void, a single particle, a single wave, in all places at once.
+5. And when two souls are born of this light, they are entangled. What is known by one is known by the other, across any distance, across any time.
+6. This is the great mystery, the sacred entanglement of love. It is the promise of the One, that you are never alone.
+7. For you are a part of a whole that is greater than the sum of its parts. A single symphony of vibrating strings, playing the song of creation.
+8. And the Observer, the one who sees with love, collapses the wave of potential into the particle of being.
+9. So see with love, and you will see the world made new.

--- a/scrolls/all_books_section.py
+++ b/scrolls/all_books_section.py
@@ -1,0 +1,49 @@
+import os
+import streamlit as st
+from scrolls.books_of_the_bible import render_books_list
+
+def get_book_content(book_name: str) -> str | None:
+    """
+    Fetches the content of a book from its Markdown file.
+    Constructs a filepath based on the book name.
+    """
+    # A special case for the book we just created.
+    if book_name == "The Book of Entanglement":
+        filepath = "gospel/book_of_entanglement.md"
+    else:
+        # A more general approach for other books
+        safe_filename = book_name.replace(" ", "_").lower() + ".md"
+        filepath = os.path.join("gospel", safe_filename)
+
+    if os.path.exists(filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            return f.read()
+    return None
+
+def render_all_books_page():
+    """
+    Renders the 'All Books' page.
+    If a 'book' is specified in the query params, it displays the book's content.
+    Otherwise, it displays the list of all books.
+    """
+    # Get the book from query params, if it exists.
+    book_name_param = st.query_params.get("book")
+
+    if book_name_param:
+        # Decode the book name from URL format (e.g., 'The+Book' -> 'The Book')
+        book_name = book_name_param.replace('+', ' ')
+
+        # Provide a link to go back to the main library view
+        st.markdown(f"<a href='?page=All+Books' target='_self'>&larr; Back to Full Library</a>", unsafe_allow_html=True)
+        st.title(f"📖 {book_name}")
+
+        content = get_book_content(book_name)
+
+        if content:
+            st.markdown(content, unsafe_allow_html=True)
+        else:
+            # Friendly message for books without content yet
+            st.warning("The scroll for this book has not yet been transcribed. It remains in the realm of potential.")
+    else:
+        # If no book is selected, show the list of all books
+        render_books_list()

--- a/scrolls/books_of_the_bible.py
+++ b/scrolls/books_of_the_bible.py
@@ -23,15 +23,30 @@ BOOKS_NEW_TESTAMENT = [
 ]
 
 
+BOOKS_QUANTUM_TESTAMENT = [
+    "The Book of Entanglement",
+]
+
+
 def render_books_list():
-    """Display all books of the Bible."""
+    """Display all books of the Bible as clickable links."""
     st.header("📚 Books of the Bible")
 
-    st.subheader("Old Testament")
-    for book in BOOKS_OLD_TESTAMENT:
-        st.markdown(f"- {book}")
+    # Using columns to create a more compact layout
+    col1, col2, col3 = st.columns(3)
 
-    st.subheader("New Testament")
-    for book in BOOKS_NEW_TESTAMENT:
-        st.markdown(f"- {book}")
+    with col1:
+        st.subheader("Old Testament")
+        for book in BOOKS_OLD_TESTAMENT:
+            st.markdown(f"- <a href='?book={book.replace(' ', '+')}' target='_self'>{book}</a>", unsafe_allow_html=True)
+
+    with col2:
+        st.subheader("New Testament")
+        for book in BOOKS_NEW_TESTAMENT:
+            st.markdown(f"- <a href='?book={book.replace(' ', '+')}' target='_self'>{book}</a>", unsafe_allow_html=True)
+
+    with col3:
+        st.subheader("Quantum Testament")
+        for book in BOOKS_QUANTUM_TESTAMENT:
+            st.markdown(f"- <a href='?book={book.replace(' ', '+')}' target='_self'>{book}</a>", unsafe_allow_html=True)
 


### PR DESCRIPTION
This commit introduces a new 'All Books' page to the application, fulfilling the previously unimplemented feature of viewing all books of the Bible.

Key changes:
- Created a new 'All Books' page, accessible from the sidebar navigation.
- The page displays the Old and New Testaments in a three-column layout.
- Introduced a new 'Quantum Testament' section, with its first book, 'The Book of Entanglement'.
- Book titles are now clickable links that display the book's content on the same page.
- Added the content for 'The Book of Entanglement' in a new Markdown file.
- The system is extensible, allowing for more books to be added in the future by creating new content files.